### PR TITLE
Feature/canonicalize all uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ here.
 
 - [Snowflake SQL Identifiers](https://docs.snowflake.net/manuals/sql-reference/identifiers-syntax.html):
   - Although Snowflake supports quoted identifiers to have non-alphanumeric values, `target-snowflake` limits
-    identifiers to lowercase alphanumerics, and underscores
+    identifiers to uppercase alphanumerics, and underscores
   - This is done to make querability/useability in Snowflake simpler, so as to not require users to _have_ to use
     sometimes cumbersome quotes to query their data
 - Requires a [JSON Schema](https://json-schema.org/) for every stream.

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,10 @@ setup(
     classifiers=['Programming Language :: Python :: 3 :: Only'],
     py_modules=['target_snowflake'],
     install_requires=[
-        'boto3==1.9.205', # Dependency conflict with snowflake and target-redshift
         'singer-python==5.6.1', # Dependency conflict with snowflake
-        'singer-target-postgres==0.1.10',
+        'singer-target-postgres==0.1.11',
         'snowflake-connector-python==1.9.0',
-        'target-redshift==0.0.9'
+        'target-redshift==0.0.10'
     ],
     setup_requires=[
         "pytest-runner"

--- a/target_snowflake/connection.py
+++ b/target_snowflake/connection.py
@@ -1,10 +1,15 @@
-import time
 import logging
+import re
+import time
 
 import singer
 from snowflake.connector import DictCursor, SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 from snowflake.connector.json_result import DictJsonResult
+
+# Ignore DEBUG, and INFO level messages from Snowflake Connector
+logger = logging.getLogger("snowflake.connector")
+logger.setLevel(logging.WARNING)
 
 
 class MillisLoggingCursor(SnowflakeCursor):
@@ -17,7 +22,7 @@ class MillisLoggingCursor(SnowflakeCursor):
             self.connection.LOGGER.info(
             "MillisLoggingCursor: {} millis spent executing: {}".format(
                 int((time.monotonic() - timestamp) * 1000),
-                command
+                re.sub(r'\n', '  \\\\n  ', command)
             ))
 
         return self

--- a/target_snowflake/snowflake.py
+++ b/target_snowflake/snowflake.py
@@ -29,7 +29,7 @@ class SnowflakeTarget(SQLInterface):
     DEFAULT_COLUMN_LENGTH = 1000
     MAX_VARCHAR = 65535
 
-    CREATE_TABLE_INITIAL_COLUMN = '_sdc_target_snowflake_create_table_placeholder'
+    CREATE_TABLE_INITIAL_COLUMN = '_SDC_TARGET_SNOWFLAKE_CREATE_TABLE_PLACEHOLDER'
     CREATE_TABLE_INITIAL_COLUMN_TYPE = 'BOOLEAN'
 
     def __init__(self, connection, s3, *args, logging_level=None, persist_empty_tables=False, **kwargs):
@@ -198,7 +198,7 @@ class SnowflakeTarget(SQLInterface):
                                     sql.identifier(self.connection.configured_schema)),
                                 'stream_table_old': sql.identifier(table_name +
                                                                 SEPARATOR +
-                                                                'old'),
+                                                                'OLD'),
                                 'stream_table': sql.identifier(table_name),
                                 'version_table': sql.identifier(versioned_table_name)}
 
@@ -240,7 +240,7 @@ class SnowflakeTarget(SQLInterface):
         if not identifier:
             identifier = '_'
 
-        return re.sub(r'[^\w\d_]', '_', identifier.lower())
+        return re.sub(r'[^\w\d_]', '_', identifier.upper())
 
     def add_key_properties(self, cur, table_name, key_properties):
         if not key_properties:
@@ -334,14 +334,14 @@ class SnowflakeTarget(SQLInterface):
         cxt_where = ' AND '.join(cxt_where_list)
 
         sequence_join = ' AND "dedupped".{} >= {}.{}'.format(
-            sql.identifier(SINGER_SEQUENCE),
+            SINGER_SEQUENCE,
             full_table_name,
-            sql.identifier(SINGER_SEQUENCE))
+            SINGER_SEQUENCE)
 
         distinct_order_by = ' ORDER BY {}, {}.{} DESC'.format(
             pk_temp_select,
             full_temp_table_name,
-            sql.identifier(SINGER_SEQUENCE))
+            SINGER_SEQUENCE)
 
         if len(subkeys) > 0:
             pk_temp_subkey_select_list = []
@@ -353,7 +353,7 @@ class SnowflakeTarget(SQLInterface):
             insert_distinct_order_by = ' ORDER BY {}, {}.{} DESC'.format(
                 insert_distinct_on,
                 full_temp_table_name,
-                sql.identifier(SINGER_SEQUENCE))
+                SINGER_SEQUENCE)
         else:
             insert_distinct_on = pk_temp_select
             insert_distinct_order_by = distinct_order_by
@@ -441,7 +441,7 @@ class SnowflakeTarget(SQLInterface):
                 self.s3.credentials()['aws_access_key_id'],
                 self.s3.credentials()['aws_secret_access_key']])
 
-        pattern = re.compile(SINGER_LEVEL.format('[0-9]+'))
+        pattern = re.compile(SINGER_LEVEL.upper().format('[0-9]+'))
         subkeys = list(filter(lambda header: re.match(pattern, header) is not None, columns))
 
         canonicalized_key_properties = [self.fetch_column_from_path((key_property,), remote_schema)[0]
@@ -458,15 +458,15 @@ class SnowflakeTarget(SQLInterface):
     def write_table_batch(self, cur, table_batch, metadata):
         remote_schema = table_batch['remote_schema']
 
-        target_table_name = 'tmp_' + str(uuid.uuid4()).replace('-', '_')
 
         ## Create temp table to upload new data to
-        target_schema = deepcopy(remote_schema)
-        target_schema['path'] = (target_table_name,)
-        self.upsert_table_helper(cur,
-                                 target_schema,
-                                 {'version': remote_schema['version']},
-                                 log_schema_changes=False)
+        _target_table_name = 'TMP_' + str(uuid.uuid4()).replace('-', '_')
+        _target_schema = deepcopy(remote_schema)
+        _target_schema['path'] = (_target_table_name,)
+        target_schema = self.upsert_table_helper(cur,
+                                                 _target_schema,
+                                                 {'version': remote_schema['version']},
+                                                 log_schema_changes=False)
 
         ## Make streamable CSV records
         csv_headers = list(remote_schema['schema']['properties'].keys())
@@ -488,7 +488,7 @@ class SnowflakeTarget(SQLInterface):
         ## Persist csv rows
         self.persist_csv_rows(cur,
                               remote_schema,
-                              target_table_name,
+                              target_schema['name'],
                               csv_headers,
                               csv_rows)
 

--- a/target_snowflake/snowflake.py
+++ b/target_snowflake/snowflake.py
@@ -333,15 +333,17 @@ class SnowflakeTarget(SQLInterface):
         pk_null = ' AND '.join(pk_null_list)
         cxt_where = ' AND '.join(cxt_where_list)
 
+        sequence_identifier = sql.identifier(self.canonicalize_identifier(SINGER_SEQUENCE))
+
         sequence_join = ' AND "dedupped".{} >= {}.{}'.format(
-            SINGER_SEQUENCE,
+            sequence_identifier,
             full_table_name,
-            SINGER_SEQUENCE)
+            sequence_identifier)
 
         distinct_order_by = ' ORDER BY {}, {}.{} DESC'.format(
             pk_temp_select,
             full_temp_table_name,
-            SINGER_SEQUENCE)
+            sequence_identifier)
 
         if len(subkeys) > 0:
             pk_temp_subkey_select_list = []
@@ -353,7 +355,7 @@ class SnowflakeTarget(SQLInterface):
             insert_distinct_order_by = ' ORDER BY {}, {}.{} DESC'.format(
                 insert_distinct_on,
                 full_temp_table_name,
-                SINGER_SEQUENCE)
+                sequence_identifier)
         else:
             insert_distinct_on = pk_temp_select
             insert_distinct_order_by = distinct_order_by
@@ -460,7 +462,7 @@ class SnowflakeTarget(SQLInterface):
 
 
         ## Create temp table to upload new data to
-        _target_table_name = 'TMP_' + str(uuid.uuid4()).replace('-', '_')
+        _target_table_name = 'tmp_' + str(uuid.uuid4()).replace('-', '_')
         _target_schema = deepcopy(remote_schema)
         _target_schema['path'] = (_target_table_name,)
         target_schema = self.upsert_table_helper(cur,


### PR DESCRIPTION
# Motivation

Snowflake deals with identifiers _best_ when they are uppercased. Stitch transforms all identifiers to uppercase. Thus, our original canonicalization was off base.