### PR TITLE
Performance: REMOVEing from an internal table stage before a DROP TABLE command is redundant

### DIFF
--- a/target_snowflake/snowflake.py
+++ b/target_snowflake/snowflake.py
@@ -413,15 +413,6 @@ class SnowflakeTarget(SQLInterface):
                 insert_columns=insert_columns,
                 dedupped_columns=dedupped_columns))
 
-        # Clear out the associated stage for the table
-        cur.execute('''
-            REMOVE @{db}.{schema}.%{temp_table}
-        '''.format(
-            db=sql.identifier(self.connection.configured_database),
-            schema=sql.identifier(self.connection.configured_schema),
-            temp_table=sql.identifier(temp_table_name)
-        ))
-
         # Drop the tmp table
         cur.execute('''
             DROP TABLE {temp_table};

--- a/target_snowflake/snowflake.py
+++ b/target_snowflake/snowflake.py
@@ -413,6 +413,15 @@ class SnowflakeTarget(SQLInterface):
                 insert_columns=insert_columns,
                 dedupped_columns=dedupped_columns))
 
+        if not self.s3:
+            # Clear out the associated stage for the table
+            cur.execute('''
+                REMOVE @{db}.{schema}.%{temp_table}
+            '''.format(
+                db=sql.identifier(self.connection.configured_database),
+                schema=sql.identifier(self.connection.configured_schema),
+                temp_table=sql.identifier(temp_table_name)))
+
         # Drop the tmp table
         cur.execute('''
             DROP TABLE {temp_table};


### PR DESCRIPTION
# Motivation

`REMOVE` commands account for about 1-2% of total running time. After running a simple test, they **_are necessary_** as `DROP`ping the `TABLE` does not delete the contents of the internal stage!

However, if we are using an external storage device, we can ignore purging the contents.


## Investigation into DROP, UNDROP and REMOVE

```sql
list @"TARGET_SNOWFLAKE_TEST"."another_snowflake_test".%"TMP_45242A2C_1B3E_4202_988F_718A91A3B91A"

> Row | name | size
> --- | --- | ---
> 1 523cc61f_f3d2_4eed_bb4e_d87d50c110bf.gz 1888

drop table "TARGET_SNOWFLAKE_TEST"."another_snowflake_test"."TMP_45242A2C_1B3E_4202_988F_718A91A3B91A"

> TMP_45242A2C_1B3E_4202_988F_718A91A3B91A successfully dropped.

list @"TARGET_SNOWFLAKE_TEST"."another_snowflake_test".%"TMP_45242A2C_1B3E_4202_988F_718A91A3B91A"

> SQL compilation error: Stage 'TARGET_SNOWFLAKE_TEST."another_snowflake_test"."%TMP_45242A2C_1B3E_4202_988F_718A91A3B91A"' does not exist.

undrop table "TMP_45242A2C_1B3E_4202_988F_718A91A3B91A"

> Table TMP_45242A2C_1B3E_4202_988F_718A91A3B91A successfully restored.

list @"TARGET_SNOWFLAKE_TEST"."another_snowflake_test".%"TMP_45242A2C_1B3E_4202_988F_718A91A3B91A"

> Row | name | size
> --- | --- | ---
> 1 523cc61f_f3d2_4eed_bb4e_d87d50c110bf.gz 1888
```