### PR TITLE
Fix regex check for column name

### DIFF
--- a/target_snowflake/sql.py
+++ b/target_snowflake/sql.py
@@ -21,11 +21,11 @@ def valid_identifier(x):
             IDENTIFIER_FIELD_LENGTH,
             len(x),
             x))
-
-    if not re.match(r'^[a-zA-Z_]\w+$', x):
+    
+    if not re.match(r'^[a-zA-Z_](\w+)?$', x):
         raise SQLError(
-            'Identifier must only contain alphanumerics, or underscores, and start with alphas. Got `{}` for `{}`'.format(
-                re.findall(r'[^0-9]', '1234a567')[0],
+            'Identifier must only contain alphanumerics, or underscores, and start with alphas. Found `{}` from name `{}`'.format(
+                re.findall(r'[^0-9a-zA-Z_]', x),
                 x
             ))
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -221,7 +221,6 @@ class CatStream(FakeStream):
             'adoption': adoption
         }
 
-
 class InvalidCatStream(CatStream):
     def generate_record(self):
         record = CatStream.generate_record(self)
@@ -432,6 +431,29 @@ class MultiTypeStream(FakeStream):
             'number_which_only_comes_as_integer': value_integer
         }
 
+
+SINGLE_CHAR_SCHEMA = {
+    'type': 'SCHEMA',
+    'stream': 'root',
+    'schema': {
+        'additionalProperties': False,
+        'properties': {
+            'x': {
+                'type': 'integer'
+            }
+        }
+    },
+    'key_properties': []
+}
+
+class SingleCharStream(FakeStream):
+    stream = 'root'
+    schema = SINGLE_CHAR_SCHEMA
+
+    def generate_record(self):
+        return {
+            'x': random.randint(-314159265359, 314159265359)
+        }
 
 
 def clear_schema():


### PR DESCRIPTION
The current regex check fails for single-character columns (I created a tap with a variable called "X"), please review at your earliest convenience, thanks!

Sorry, i had to re-send #28  because i need to switch out the branch