### PR TITLE
Data insertion optimization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=['target_snowflake'],
     install_requires=[
         'singer-python==5.9.0',
-        'singer-target-postgres==0.2.4',
+        'singer-target-postgres@git+https://github.com/datamill-co/target-postgres.git#279cb62d2a80b1bd8e8ab1191e7a1d17c19383a8',
         'target-redshift==0.2.4',
         'botocore<1.13.0,>=1.12.253',
         'snowflake-connector-python==2.2.5'

--- a/target_snowflake/snowflake.py
+++ b/target_snowflake/snowflake.py
@@ -288,7 +288,7 @@ class SnowflakeTarget(SQLInterface):
 
     def serialize_table_record_null_value(self, remote_schema, streamed_schema, field, value):
         if value is None:
-            return '\\\\N'
+            return '\\N'
         return value
 
     def serialize_table_record_datetime_value(self, remote_schema, streamed_schema, field, value):
@@ -521,12 +521,15 @@ class SnowflakeTarget(SQLInterface):
         csv_headers = list(remote_schema['schema']['properties'].keys())
         rows_iter = iter(table_batch['records'])
 
+        csv_dialect = csv.unix_dialect()
+        csv_dialect.escapechar = '\\'
+
         def transform():
             try:
                 row = next(rows_iter)
 
                 with io.StringIO() as out:
-                    writer = csv.DictWriter(out, csv_headers)
+                    writer = csv.DictWriter(out, csv_headers, dialect=csv_dialect)
                     writer.writerow(row)
                     return out.getvalue()
             except StopIteration:

--- a/target_snowflake/snowflake.py
+++ b/target_snowflake/snowflake.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import uuid
+from functools import lru_cache
 
 import arrow
 from psycopg2 import sql
@@ -20,6 +21,16 @@ from target_postgres.sql_base import SEPARATOR, SQLInterface
 from target_snowflake import sql
 from target_snowflake.connection import connect
 from target_snowflake.exceptions import SnowflakeError
+
+# copied in from optimization in PostgresTarget: https://github.com/datamill-co/target-postgres/commit/6a3da026d2bb4681fdf46bd7ca69fbb164489d8a
+@lru_cache(maxsize=128)
+def _format_datetime(value):
+    """
+    Format a datetime value. This is only called from the
+    SnowflakeTarget.serialize_table_record_datetime_value
+    but this non-method version allows caching
+    """
+    return arrow.get(value).format('YYYY-MM-DD HH:mm:ss.SSSSZZ')
 
 class SnowflakeTarget(SQLInterface):
     """
@@ -288,11 +299,11 @@ class SnowflakeTarget(SQLInterface):
 
     def serialize_table_record_null_value(self, remote_schema, streamed_schema, field, value):
         if value is None:
-            return '\\N'
+            return '\\\\N'
         return value
 
     def serialize_table_record_datetime_value(self, remote_schema, streamed_schema, field, value):
-        return arrow.get(value).format('YYYY-MM-DD HH:mm:ss.SSSSZZ')
+        return _format_datetime(value)
 
     def perform_update(self, cur, target_table_name, temp_table_name, key_properties, columns, subkeys):
         full_table_name = '{}.{}.{}'.format(
@@ -503,8 +514,11 @@ class SnowflakeTarget(SQLInterface):
             subkeys)
 
     def write_table_batch(self, cur, table_batch, metadata):
-        remote_schema = table_batch['remote_schema']
+        record_count = len(table_batch['records'])
+        if record_count == 0:
+            return 0
 
+        remote_schema = table_batch['remote_schema']
 
         ## Create temp table to upload new data to
         target_table_name = self.canonicalize_identifier('tmp_' + str(uuid.uuid4()))
@@ -544,7 +558,7 @@ class SnowflakeTarget(SQLInterface):
                               csv_headers,
                               csv_rows)
 
-        return len(table_batch['records'])
+        return record_count
 
     def add_column(self, cur, table_name, column_name, column_schema):
 

--- a/target_snowflake/snowflake.py
+++ b/target_snowflake/snowflake.py
@@ -586,8 +586,8 @@ class SnowflakeTarget(SQLInterface):
             '''.format(
             database=sql.identifier(self.connection.configured_database),
             table_schema=sql.identifier(self.connection.configured_schema),
-            table_name=sql.Identifier(table_name),
-            column_name=sql.Identifier(column_name)))
+            table_name=sql.identifier(table_name),
+            column_name=sql.identifier(column_name)))
 
     def _set_table_metadata(self, cur, table_name, metadata):
         """


### PR DESCRIPTION
Update the `target-postgres` dependency to get the latest master branch commit, which is many commits ahead of the 0.2.4 package version. This provides several performance optimizations that have been added, such as:

* Multiple optimizations: https://github.com/datamill-co/target-postgres/pull/204
* Reduce state message memory footprint: https://github.com/datamill-co/target-postgres/pull/212

Additionally, bypass table insertion work when the record count is zero. The code still respects the `persist_empty_tables` setting to manage the table schema itself, but will not go through the expensive process to perform a zero-record insertion. That process takes ~6s per table and is effectively a no-op. For table-heavy taps, this saves a lot of wasted time.

# Testing
Tested locally with a few of my own taps. A tap with ~25 tables and no new data was able to run in ~40 instead of ~1m45s, mostly due to the code which skips table data insertion when the data batch has zero records.